### PR TITLE
Enable Dependabot for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This might work now that
https://github.com/dependabot/dependabot-core/issues/4483 has been
fixed.
